### PR TITLE
Switch to the regular version of Documenter.jl

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,9 @@
 [deps]
-FastLapackInterface = "29a986be-02c6-4525-aec4-84b980013641"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+FastLapackInterface = "29a986be-02c6-4525-aec4-84b980013641"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[compat]
+Documenter = "0.27"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -27,7 +27,7 @@ Pkg.activate(@__DIR__)
 # if !isfile(joinpath(@__DIR__, "Manifest.toml"))
 Pkg.develop(Pkg.PackageSpec(; path = ROOTPATH))
 Pkg.instantiate()
-Pkg.add(; url = "https://github.com/kimikage/Documenter.jl", rev = "ansicolor")
+Pkg.add(; url = "https://github.com/JuliaDocs/Documenter.jl")
 # end
 
 # Setup environment for making plots


### PR DESCRIPTION
@MichelJuillard @louisponet Right now I am stick with Louis `make.jl` code. I have not cleaned it up. As I mentioned we are having some errors. When those errors will be resolved I will make changes accordingly. 

Now, we are using regular version of `Documenter.jl`.