### PR TITLE
Resizing support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FastLapackInterface"
 uuid = "29a986be-02c6-4525-aec4-84b980013641"
 authors = ["Louis Ponet, Michel Juillard"]
-version = "1.1.0"
+version = "1.2.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ decompose!(ws, A)
 A similar API exists for the above decompositions. For more information and examples please see the [documentation](https://dynarejulia.github.io/FastLapackInterface.jl/dev/).
 
 ## Package version
--   v1.x: works only with Julia >= 1.7
+-   v1.x: works only with Julia >= 1.6.3

--- a/benchmark/bench_qr.jl
+++ b/benchmark/bench_qr.jl
@@ -90,21 +90,21 @@ for n in sizes
     suite["QRWYWs"]["geqrt!"]["LAPACK"]["$n"]    = @benchmarkable bench_geqrt!($As, $T)
 end
 
-###### QRpWs
+###### QRPivotedWs
 
-suite["QRpWs"] = BenchmarkGroup()
-suite["QRpWs"]["creation"] = BenchmarkGroup()
+suite["QRPivotedWs"] = BenchmarkGroup()
+suite["QRPivotedWs"]["creation"] = BenchmarkGroup()
 for n in sizes
-    suite["QRpWs"]["creation"]["$n"] = @benchmarkable QRWYWs(A) setup = (A = rand($n, $n))
+    suite["QRPivotedWs"]["creation"]["$n"] = @benchmarkable QRWYWs(A) setup = (A = rand($n, $n))
 end
 
 for n in sizes
-    suite["QRpWs"]["creation"]["$n"] = @benchmarkable QRWYWs(A) setup = (A = rand($n, $n))
+    suite["QRPivotedWs"]["creation"]["$n"] = @benchmarkable QRWYWs(A) setup = (A = rand($n, $n))
 end
 
-suite["QRpWs"]["geqp3!"]              = BenchmarkGroup()
-suite["QRpWs"]["geqp3!"]["workspace"] = BenchmarkGroup()
-suite["QRpWs"]["geqp3!"]["LAPACK"]    = BenchmarkGroup()
+suite["QRPivotedWs"]["geqp3!"]              = BenchmarkGroup()
+suite["QRPivotedWs"]["geqp3!"]["workspace"] = BenchmarkGroup()
+suite["QRPivotedWs"]["geqp3!"]["LAPACK"]    = BenchmarkGroup()
 
 function bench_geqp3!(As, ws)
     for A in As
@@ -121,10 +121,10 @@ for n in sizes
     As   = [rand(n, n) for i in 1:vector_length]
     τ    = zeros(n)
     lpvt = zeros(Int, n)
-    ws   = QRpWs(As[1])
+    ws   = QRPivotedWs(As[1])
 
-    suite["QRpWs"]["geqp3!"]["workspace"]["$n"] = @benchmarkable bench_geqp3!($As, $ws)
-    suite["QRpWs"]["geqp3!"]["LAPACK"]["$n"]    = @benchmarkable bench_geqp3!($As, $lpvt, $τ)
+    suite["QRPivotedWs"]["geqp3!"]["workspace"]["$n"] = @benchmarkable bench_geqp3!($As, $ws)
+    suite["QRPivotedWs"]["geqp3!"]["LAPACK"]["$n"]    = @benchmarkable bench_geqp3!($As, $lpvt, $τ)
 end
 
 end

--- a/docs/src/LAPACK.md
+++ b/docs/src/LAPACK.md
@@ -1,4 +1,5 @@
 # [LAPACK](@id LAPACK)
+This section details the [`LAPACK functions`](https://docs.julialang.org/en/v1/stdlib/LinearAlgebra/#LinearAlgebra.LAPACK) that are supported for use with various [`Workspaces`](@ref WorkSpaces). Each function has a `resize` keyword argument that is `true` by default, allowing for automatic resizing of the workspaces to accomodate larger Matrices or different features than they were originally constructed for.
 
 ## Unified Interface
 After having created the [`Workspace`](@ref WorkSpaces) that corresponds to the targeted factorization or decomposition,

--- a/docs/src/LAPACK.md
+++ b/docs/src/LAPACK.md
@@ -15,7 +15,7 @@ factorize!
 LinearAlgebra.LAPACK.geqrf!(::QRWs, ::AbstractMatrix)
 LinearAlgebra.LAPACK.ormqr!(::QRWs, ::AbstractChar, ::AbstractChar, ::AbstractMatrix, ::AbstractVecOrMat)
 LinearAlgebra.LAPACK.geqrt!(::QRWYWs, ::AbstractMatrix)
-LinearAlgebra.LAPACK.geqp3!(::QRpWs, ::AbstractMatrix)
+LinearAlgebra.LAPACK.geqp3!(::QRPivotedWs, ::AbstractMatrix)
 ```
 
 ## Schur

--- a/docs/src/workspaces.md
+++ b/docs/src/workspaces.md
@@ -8,6 +8,10 @@ This can then be used to perform the decompositions without extra allocations.
 ```@docs
 Workspace
 ```
+Each [`Workspace`](@ref) also has a function to [`resize!`](@ref) to allow for its use with larger matrices or with more features (e.g. the computation of left eigenvectors and right eigenvectors using [`EigenWs`](@ref)).
+```@docs
+resize!(::Workspace, ::AbstractMatrix; kwargs...)
+```
 
 ## [QR](@id QR-id)
 

--- a/docs/src/workspaces.md
+++ b/docs/src/workspaces.md
@@ -18,7 +18,7 @@ resize!(::Workspace, ::AbstractMatrix; kwargs...)
 ```@docs
 QRWs
 QRWYWs
-QRpWs
+QRPivotedWs
 ```
 
 ## [Schur](@id Schur-id)

--- a/src/FastLapackInterface.jl
+++ b/src/FastLapackInterface.jl
@@ -20,7 +20,7 @@ abstract type Workspace end
 include("lu.jl")
 export LUWs
 include("qr.jl")
-export QRWs, QRWYWs, QRpWs
+export QRWs, QRWYWs, QRPivotedWs
 include("schur.jl")
 export SchurWs, GeneralizedSchurWs
 include("eigen.jl")

--- a/src/qr.jl
+++ b/src/qr.jl
@@ -73,7 +73,7 @@ for (geqrf, elty) in ((:dgeqrf_, :Float64),
                 if resize
                     resize!(ws, A)
                 else
-                    throw(DimensionMismatch("Allocated workspace has length $(length(ws)), but needs length $(min(m,n))"))
+                    throw(ArgumentError("Workspace is too small, use resize!(ws, A)."))
                 end
             end
             lda = max(1, stride(A, 2))
@@ -241,10 +241,12 @@ for (geqrt, elty) in ((:dgeqrt_, :Float64),
             if nb > minmn
                 if resize
                     resize!(ws, A)
+                    nb = size(ws.T, 1)
                 else
-                    throw(ArgumentError("Allocated workspace block size $nb > $minmn too large."))
+                    throw(ArgumentError("Allocated workspace block size $nb > $minmn too large.\nUse resize!(ws, A)."))
                 end
             end
+            
             lda = max(1, stride(A, 2))
             work = ws.work
             info = Ref{BlasInt}()
@@ -352,14 +354,14 @@ for (geqp3, elty) in ((:dgeqp3_, :Float64),
                 if resize
                     resize!(ws, A)
                 else
-                    throw(DimensionMismatch("τ  has length $(length(ws.τ)), but needs length $(min(m,n))"))
+                    throw(ArgumentError("Workspace is too small, use resize!(ws, A)."))
                 end
             end
             if length(ws.jpvt) != n
                 if resize
                     resize!(ws, A)
                 else
-                    throw(DimensionMismatch("jpvt has length $(length(ws.jpvt)), but needs length $n"))
+                    throw(ArgumentError("Workspace is too small, use resize!(ws, A)."))
                 end
             end
             lda = stride(A, 2)

--- a/src/qr.jl
+++ b/src/qr.jl
@@ -49,28 +49,32 @@ for (geqrf, elty) in ((:dgeqrf_, :Float64),
                       (:zgeqrf_, :ComplexF64),
                       (:cgeqrf_, :ComplexF32))
     @eval begin
-        function QRWs(A::StridedMatrix{$elty})
+        function Base.resize!(ws::QRWs, A::StridedMatrix{$elty})
             m, n = size(A)
             lda = max(1, stride(A, 2))
-            τ = zeros($elty, min(m, n))
-            work = Vector{$elty}(undef, 1)
-            lwork = -1
+            resize!(ws.τ, min(m, n))
             info = Ref{BlasInt}()
             ccall((@blasfunc($geqrf), liblapack), Cvoid,
                   (Ref{BlasInt}, Ref{BlasInt}, Ptr{$elty}, Ref{BlasInt}, Ptr{$elty},
                    Ptr{$elty}, Ref{BlasInt}, Ptr{BlasInt}),
-                  m, n, A, lda, τ, work, lwork, info)
+                  m, n, A, lda, ws.τ, ws.work, -1, info)
             chklapackerror(info[])
-            resize!(work, BlasInt(real(work[1])))
-            return QRWs(work, τ)
+            resize!(ws.work, BlasInt(real(ws.work[1])))
+            return ws
         end
+        QRWs(A::StridedMatrix{$elty}) =
+            resize!(QRWs(Vector{$elty}(undef, 1), Vector{$elty}(undef, 1)), A)
 
-        function geqrf!(ws::QRWs, A::AbstractMatrix{$elty})
+        function geqrf!(ws::QRWs, A::AbstractMatrix{$elty}; resize=true)
             require_one_based_indexing(A)
             chkstride1(A)
             m, n = size(A)
-            if length(ws) != min(m, n)
-                throw(DimensionMismatch("Allocated workspace has length $(length(ws)), but needs length $(min(m,n))"))
+            if length(ws) < min(m, n)
+                if resize
+                    resize!(ws, A)
+                else
+                    throw(DimensionMismatch("Allocated workspace has length $(length(ws)), but needs length $(min(m,n))"))
+                end
             end
             lda = max(1, stride(A, 2))
             lwork = length(ws.work)
@@ -90,7 +94,7 @@ for (ormqr, elty) in ((:dormqr_, :Float64),
     @eval begin
         function ormqr!(ws::QRWs{$elty}, side::AbstractChar, trans::AbstractChar,
                         A::AbstractMatrix{$elty},
-                        C::AbstractVecOrMat{$elty})
+                        C::AbstractVecOrMat{$elty}; resize=true)
             require_one_based_indexing(A, C)
             chktrans(trans)
             chkside(side)
@@ -141,15 +145,17 @@ for (ormqr, elty) in ((:dormqr_, :Float64),
 end
 
 """
-    geqrf!(ws, A) -> (A, ws.τ)
+    geqrf!(ws, A; resize=true) -> (A, ws.τ)
 
 Compute the `QR` factorization of `A`, `A = QR`, using previously allocated [`QRWs`](@ref) workspace `ws`.
 `ws.τ` contains scalars which parameterize the elementary reflectors of the factorization.
 `ws.τ` must have length greater than or equal to the smallest dimension of `A`.
+If this is not the case, and `resize==true` the workspace will be automatically
+resized to the appropriate size.
 
 `A` and `ws.τ` modified in-place.
 """
-geqrf!(ws::QRWs, A::AbstractMatrix)
+geqrf!(ws::QRWs, A::AbstractMatrix; kwargs...)
 
 """
     ormqr!(ws, side, trans, A, C) -> C
@@ -202,7 +208,7 @@ julia> Matrix(t)
  6.2  3.3
 ```
 """
-struct QRWYWs{R<:Number,MT<:StridedMatrix{R}} <: Workspace
+mutable struct QRWYWs{R<:Number,MT<:StridedMatrix{R}} <: Workspace
     work::Vector{R}
     T::MT
 end
@@ -212,27 +218,32 @@ for (geqrt, elty) in ((:dgeqrt_, :Float64),
                       (:zgeqrt_, :ComplexF64),
                       (:cgeqrt_, :ComplexF32))
     @eval begin
-        function QRWYWs(A::StridedMatrix{$elty}; blocksize = 36)
+        function Base.resize!(ws::QRWYWs, A::StridedMatrix; blocksize=36)
             require_one_based_indexing(A)
             chkstride1(A)
             m, n = BlasInt.(size(A))
             @assert n > 0 ArgumentError("Not a Matrix")
             m1 = min(m, n)
             nb = min(m1, blocksize)
-            T = zeros($elty, nb, m1)
-
-            work = zeros($elty, nb * n)
-            return QRWYWs(work, T)
+            ws.T = similar(ws.T,  nb, m1)
+            resize!(ws.work, nb*n)
+            return ws
         end
+        QRWYWs(A::StridedMatrix{$elty}; kwargs...) = 
+            resize!(QRWYWs($elty[], Matrix{$elty}(undef, 0, 0)), A; kwargs...)
 
-        function geqrt!(ws::QRWYWs, A::AbstractMatrix{$elty})
+        function geqrt!(ws::QRWYWs, A::AbstractMatrix{$elty}; resize=true)
             require_one_based_indexing(A)
             chkstride1(A)
             m, n = size(A)
             minmn = min(m, n)
             nb = size(ws.T, 1)
             if nb > minmn
-                throw(ArgumentError("Allocated workspace block size $nb > $minmn too large."))
+                if resize
+                    resize!(ws, A)
+                else
+                    throw(ArgumentError("Allocated workspace block size $nb > $minmn too large."))
+                end
             end
             lda = max(1, stride(A, 2))
             work = ws.work
@@ -251,20 +262,21 @@ for (geqrt, elty) in ((:dgeqrt_, :Float64),
 end
 
 """
-    geqrt!(ws, A) -> (A, ws.T)
+    geqrt!(ws, A; resize=true) -> (A, ws.T)
 
 Compute the blocked `QR` factorization of `A`, `A = QR`, using a preallocated [`QRWYWs`](@ref) workspace `ws`. `ws.T` contains upper
 triangular block reflectors which parameterize the elementary reflectors of
 the factorization. The first dimension of `ws.T` sets the block size and it must
 satisfy `1 <= size(ws.T, 1) <= min(size(A)...)`. The second dimension of `T` must equal the smallest
-dimension of `A`, i.e. `size(ws.T, 2) == size(A, 2)`.
+dimension of `A`, i.e. `size(ws.T, 2) == size(A, 2)`. If this is not the case and
+`resize==true`, the workspace will automatically be resized to the appropriate dimensions.
 
 `A` and `ws.T` are modified in-place.
 """
-geqrt!(ws::QRWYWs, A::AbstractMatrix)
+geqrt!(ws::QRWYWs, A::AbstractMatrix; kwargs...)
 
 """
-    QRpWs
+    QRPivotedWs
 
 Workspace to be used with the [`LinearAlgebra.QRPivoted`](https://docs.julialang.org/en/v1/stdlib/LinearAlgebra/#LinearAlgebra.QRPivoted)
 representation of the QR factorization which uses the [`LAPACK.geqp3!`](@ref) function.
@@ -277,8 +289,8 @@ julia> A = [1.2 2.3
  1.2  2.3
  6.2  3.3
 
-julia> ws = QRpWs(A)
-QRpWs{Float64}
+julia> ws = QRPivotedWs(A)
+QRPivotedWs{Float64}
   work: 100-element Vector{Float64}
   τ: 2-element Vector{Float64}
   jpvt: 2-element Vector{Int64}
@@ -304,7 +316,7 @@ julia> Matrix(t)
  6.2  3.3
 ```
 """
-struct QRpWs{T<:Number} <: Workspace
+struct QRPivotedWs{T<:Number} <: Workspace
     work::Vector{T}
     τ::Vector{T}
     jpvt::Vector{BlasInt}
@@ -315,32 +327,40 @@ for (geqp3, elty) in ((:dgeqp3_, :Float64),
                       (:zgeqp3_, :ComplexF64),
                       (:cgeqp3_, :ComplexF32))
     @eval begin
-        function QRpWs(A::StridedMatrix{$elty})
+        function Base.resize!(ws::QRPivotedWs, A::StridedMatrix{$elty})
             require_one_based_indexing(A)
             chkstride1(A)
             m, n = size(A)
             RldA = max(1, stride(A, 2))
-            jpvt = zeros(BlasInt, n)
-            τ = zeros($elty, min(m, n))
-            work = Vector{$elty}(undef, 1)
-            lwork = -1
+            resize!(ws.jpvt, n)
+            resize!(ws.τ, min(m, n))
             info = Ref{BlasInt}()
             ccall((@blasfunc($geqp3), liblapack), Cvoid,
                   (Ref{BlasInt}, Ref{BlasInt}, Ptr{$elty}, Ref{BlasInt}, Ptr{BlasInt},
                    Ptr{$elty}, Ptr{$elty}, Ref{BlasInt}, Ref{BlasInt}),
-                  m, n, A, RldA, jpvt, τ, work, lwork, info)
+                  m, n, A, RldA, ws.jpvt, ws.τ, ws.work, -1, info)
             chklapackerror(info[])
-            work = resize!(work, BlasInt(real(work[1])))
-            return QRpWs(work, τ, jpvt)
+            resize!(ws.work, BlasInt(real(ws.work[1])))
+            return ws
         end
+        QRPivotedWs(A::StridedMatrix{$elty}) = 
+            resize!(QRPivotedWs(Vector{$elty}(undef, 1), $elty[], BlasInt[]), A)
 
-        function geqp3!(ws::QRpWs{$elty}, A::AbstractMatrix{$elty})
+        function geqp3!(ws::QRPivotedWs{$elty}, A::AbstractMatrix{$elty}; resize=true)
             m, n = size(A)
             if length(ws.τ) != min(m, n)
-                throw(DimensionMismatch("τ  has length $(length(ws.τ)), but needs length $(min(m,n))"))
+                if resize
+                    resize!(ws, A)
+                else
+                    throw(DimensionMismatch("τ  has length $(length(ws.τ)), but needs length $(min(m,n))"))
+                end
             end
             if length(ws.jpvt) != n
-                throw(DimensionMismatch("jpvt has length $(length(ws.jpvt)), but needs length $n"))
+                if resize
+                    resize!(ws, A)
+                else
+                    throw(DimensionMismatch("jpvt has length $(length(ws.jpvt)), but needs length $n"))
+                end
             end
             lda = stride(A, 2)
             if lda == 0 # Early exit
@@ -361,15 +381,16 @@ for (geqp3, elty) in ((:dgeqp3_, :Float64),
 end
 
 """
-    geqp3!(ws, A) -> (A, ws.τ, ws.jpvt)
+    geqp3!(ws, A; resize=true) -> (A, ws.τ, ws.jpvt)
 
 Compute the pivoted `QR` factorization of `A`, `AP = QR` using BLAS level 3,
-using the preallocated [`QRpWs`](@ref) workspace `ws`.
+using the preallocated [`QRPivotedWs`](@ref) workspace `ws`.
 `P` is a pivoting matrix, represented by `ws.jpvt`. `ws.τ` stores the elementary
 reflectors. `ws.jpvt` must have length greater
 than or equal to `n` if `A` is an `(m x n)` matrix and `ws.τ` must have length
-greater than or equal to the smallest dimension of `A`.
+greater than or equal to the smallest dimension of `A`. If this is not the case
+and `resize == true` the workspace will be appropriately resized.
 
 `A`, `ws.jpvt`, and `ws.τ` are modified in-place.
 """
-geqp3!(ws::QRpWs, A::AbstractMatrix)
+geqp3!(ws::QRPivotedWs, A::AbstractMatrix; kwargs...)

--- a/src/schur.jl
+++ b/src/schur.jl
@@ -98,6 +98,8 @@ for (gees, elty) in ((:dgees_, :Float64),
             resize!(ws.wr, n)
             resize!(ws.wi, n)
             ws.vs = zeros($elty, n, n)
+            resize!(ws.bwork, n)
+            resize!(ws.eigen_values, n)
             info  = Ref{BlasInt}()
             ccall((@blasfunc($gees), liblapack), Cvoid,
                   (Ref{UInt8}, Ref{UInt8}, Ptr{Cvoid}, Ref{BlasInt},
@@ -127,7 +129,7 @@ for (gees, elty) in ((:dgees_, :Float64),
             n = checksquare(A)
             if n > length(ws)
                 if resize
-                    resize!(A)
+                    resize!(ws, A)
                 else
                     throw(ArgumentError("Allocated workspace has length $(length(ws)), but needs length $n."))
                 end

--- a/src/schur.jl
+++ b/src/schur.jl
@@ -91,16 +91,13 @@ Base.length(ws::SchurWs) = length(ws.wr)
 for (gees, elty) in ((:dgees_, :Float64),
                      (:sgees_, :Float32))
     @eval begin
-        function SchurWs(A::AbstractMatrix{$elty})
+        function Base.resize!(ws::SchurWs, A::AbstractMatrix{$elty})
             require_one_based_indexing(A)
             chkstride1(A)
             n     = checksquare(A)
-            wr    = zeros($elty, n)
-            wi    = zeros($elty, n)
-            vs    = zeros($elty, n, n)
-            ldvs  = max(size(vs, 1), 1)
-            work  = Vector{$elty}(undef, 1)
-            lwork = BlasInt(-1)
+            resize!(ws.wr, n)
+            resize!(ws.wi, n)
+            ws.vs = zeros($elty, n, n)
             info  = Ref{BlasInt}()
             ccall((@blasfunc($gees), liblapack), Cvoid,
                   (Ref{UInt8}, Ref{UInt8}, Ptr{Cvoid}, Ref{BlasInt},
@@ -108,24 +105,32 @@ for (gees, elty) in ((:dgees_, :Float64),
                    Ptr{$elty}, Ptr{$elty}, Ref{BlasInt}, Ptr{$elty},
                    Ref{BlasInt}, Ptr{Cvoid}, Ptr{BlasInt}, Clong, Clong),
                   'V', 'N', C_NULL, n,
-                  A, max(1, stride(A, 2)), C_NULL, wr,
-                  wi, vs, ldvs, work,
-                  lwork, C_NULL, info, 1, 1)
+                  A, max(1, stride(A, 2)), C_NULL, ws.wr,
+                  ws.wi, ws.vs, max(size(ws.vs, 1), 1), ws.work,
+                  -1, C_NULL, info, 1, 1)
 
             chklapackerror(info[])
 
-            resize!(work, BlasInt(real(work[1])))
-            return SchurWs{$elty}(work, wr, wi, vs, Ref{BlasInt}(),
-                                  Vector{BlasInt}(undef, n), similar(A, Complex{$elty}, n))
+            resize!(ws.work, BlasInt(real(ws.work[1])))
+            return ws
         end
+            
+        SchurWs(A::AbstractMatrix{$elty}) =
+            resize!(SchurWs(Vector{$elty}(undef, 1), $elty[], $elty[], Matrix{$elty}(undef, 0, 0), Ref{BlasInt}(), BlasInt[], Complex{$elty}[]), A) 
 
         function gees!(ws::SchurWs{$elty}, jobvs::AbstractChar,
-                       A::AbstractMatrix{$elty}; select::Union{Nothing,Function} = nothing)
+                       A::AbstractMatrix{$elty};
+                       select::Union{Nothing,Function} = nothing,
+                       resize=false)
             require_one_based_indexing(A)
             chkstride1(A)
             n = checksquare(A)
             if n > length(ws)
-                throw(ArgumentError("Allocated workspace has length $(length(ws)), but needs length $n."))
+                if resize
+                    resize!(A)
+                else
+                    throw(ArgumentError("Allocated workspace has length $(length(ws)), but needs length $n."))
+                end
             end
             info = Ref{BlasInt}()
             ldvs = max(size(ws.vs, 1), 1)
@@ -170,10 +175,10 @@ for (gees, elty) in ((:dgees_, :Float64),
 end
 
 """
-    gees!(ws, jobvs, A; select=nothing) -> (A, vs, ws.eigen_values)
+    gees!(ws, jobvs, A; select=nothing, resize=true) -> (A, vs, ws.eigen_values)
 
 Computes the eigenvalues (`jobvs = N`) or the eigenvalues and Schur
-vectors (`jobvs = V`) of matrix `A`, using the preallocated [`SchurWs`](@ref) worspace `ws`.
+vectors (`jobvs = V`) of matrix `A`, using the preallocated [`SchurWs`](@ref) worspace `ws`. If `ws` is not of the appropriate size and `resize==true` it will be resized for `A`. 
 `A` is overwritten by its Schur form, and `ws.eigen_values` is overwritten with the eigenvalues.
 
 It is possible to specify `select`, a function used to sort the eigenvalues during the decomponsition.
@@ -182,7 +187,7 @@ The function should have the signature `f(wr::T, wi::T) -> Bool`, where
 
 Returns `A`, `vs` containing the Schur vectors, and `ws.eigen_values`.
 """
-gees!(ws::SchurWs, jobvs::AbstractChar, A::AbstractMatrix)
+gees!(ws::SchurWs, jobvs::AbstractChar, A::AbstractMatrix; kwargs...)
 
 """
     GeneralizedSchurWs
@@ -262,16 +267,16 @@ Base.length(ws::GeneralizedSchurWs) = length(ws.αr)
 for (gges, elty) in ((:dgges_, :Float64),
                      (:sgges_, :Float32))
     @eval begin
-        function GeneralizedSchurWs(A::AbstractMatrix{$elty})
+        function Base.resize!(ws::GeneralizedSchurWs, A::AbstractMatrix{$elty})
             chkstride1(A)
             n     = checksquare(A)
-            αr    = zeros($elty, n)
-            αi    = zeros($elty, n)
-            β     = zeros($elty, n)
-            vsl   = zeros($elty, n, n)
-            vsr   = zeros($elty, n, n)
-            work  = Vector{$elty}(undef, 1)
-            lwork = BlasInt(-1)
+            resize!(ws.αr, n)
+            resize!(ws.αi, n)
+            resize!(ws.β, n)
+            resize!(ws.bwork, n)
+            resize!(ws.eigen_values, n)
+            ws.vsl = zeros($elty, n, n)
+            ws.vsr = zeros($elty, n, n)
             info  = Ref{BlasInt}()
             ccall((@blasfunc($gges), liblapack), Cvoid,
                   (Ref{UInt8}, Ref{UInt8}, Ref{UInt8}, Ptr{Cvoid},
@@ -282,29 +287,34 @@ for (gges, elty) in ((:dgges_, :Float64),
                    Ref{BlasInt}, Clong, Clong, Clong),
                   'V', 'V', 'N', C_NULL,
                   n, A, max(1, stride(A, 2)), A,
-                  max(1, stride(A, 2)), C_NULL, αr, αi,
-                  β, vsl, n, vsr,
-                  n, work, lwork, C_NULL,
+                  max(1, stride(A, 2)), C_NULL, ws.αr, ws.αi,
+                  ws.β, ws.vsl, n, ws.vsr,
+                  n, ws.work, -1, C_NULL,
                   info, 1, 1, 1)
 
             chklapackerror(info[])
-            resize!(work, BlasInt(real(work[1])))
-            return GeneralizedSchurWs(work, αr, αi, β, vsl, vsr, Ref{BlasInt}(),
-                                      Vector{BlasInt}(undef, n),
-                                      similar(A, Complex{$elty}, n))
+            resize!(ws.work, BlasInt(real(ws.work[1])))
+            return ws
         end
+        GeneralizedSchurWs(A::AbstractMatrix{$elty}) = 
+            resize!(GeneralizedSchurWs(Vector{$elty}(undef, 1), $elty[], $elty[], $elty[], Matrix{$elty}(undef, 0, 0), Matrix{$elty}(undef, 0, 0), Ref{BlasInt}(), BlasInt[], Complex{$elty}[]), A)
 
         function gges!(ws::GeneralizedSchurWs, jobvsl::AbstractChar,
                        jobvsr::AbstractChar,
                        A::AbstractMatrix{$elty}, B::AbstractMatrix{$elty};
-                       select::Union{Nothing,Function} = nothing)
+                       select::Union{Nothing,Function} = nothing,
+                       resize=true)
             chkstride1(A, B)
             n, m = checksquare(A, B)
             if n != m
                 throw(DimensionMismatch("dimensions of A, ($n,$n), and B, ($m,$m), must match"))
             end
             if n > length(ws)
-                throw(ArgumentError("Allocated workspace has length $(length(ws)), but needs length $n."))
+                if resize
+                    resize!(ws, A)
+                else
+                    throw(ArgumentError("Allocated workspace has length $(length(ws)), but needs length $n."))
+                end
             end
 
             info = Ref{BlasInt}()
@@ -353,11 +363,12 @@ for (gges, elty) in ((:dgges_, :Float64),
 end
 
 """
-    gges!(ws, jobvsl, jobvsr, A, B; select=nothing) -> (A, B, ws.eigen_values, ws.β, ws.vsl, ws.vsr)
+    gges!(ws, jobvsl, jobvsr, A, B; select=nothing, resize=true) -> (A, B, ws.eigen_values, ws.β, ws.vsl, ws.vsr)
 
 Computes the generalized eigenvalues, generalized Schur form, left Schur
 vectors (`jobsvl = V`), or right Schur vectors (`jobvsr = V`) of `A` and
 `B`, using preallocated [`GeneralizedSchurWs`](@ref) workspace `ws`.
+If `ws` is not of the right size, and `resize==true` it will be resized appropriately.
 
 It is possible to specify `select`, a function used to sort the eigenvalues during the decomposition.
 The function should have the signature `f(αr::T, αi::T, β::T) -> Bool`, where

--- a/src/workspace.jl
+++ b/src/workspace.jl
@@ -65,40 +65,40 @@ Workspace(::typeof(LAPACK.pstrf!), A::AbstractMatrix) = CholeskyPivotedWs(A)
 
 Will use the previously created [`Workspace`](@ref WorkSpaces) `ws` to dispatch to the correct LAPACK call.  
 """
-decompose!(ws::LUWs, args...) = LAPACK.getrf!(ws, args...)
+decompose!(ws::LUWs, args...; kwargs...) = LAPACK.getrf!(ws, args...; kwargs...)
 
-decompose!(ws::QRWs, args...)   = LAPACK.geqrf!(ws, args...)
-decompose!(ws::QRWYWs, args...) = LAPACK.geqrt!(ws, args...)
-decompose!(ws::QRPivotedWs, args...)  = LAPACK.geqp3!(ws, args...)
+decompose!(ws::QRWs, args...; kwargs...)   = LAPACK.geqrf!(ws, args...; kwargs...)
+decompose!(ws::QRWYWs, args...; kwargs...) = LAPACK.geqrt!(ws, args...; kwargs...)
+decompose!(ws::QRPivotedWs, args...; kwargs...)  = LAPACK.geqp3!(ws, args...; kwargs...)
 
-decompose!(ws::SchurWs, args...)            = LAPACK.gees!(ws, args...)
-decompose!(ws::GeneralizedSchurWs, args...) = LAPACK.gges!(ws, args...)
+decompose!(ws::SchurWs, args...; kwargs...)            = LAPACK.gees!(ws, args...; kwargs...)
+decompose!(ws::GeneralizedSchurWs, args...; kwargs...) = LAPACK.gges!(ws, args...; kwargs...)
 
-decompose!(ws::EigenWs, args...) = LAPACK.geevx!(ws, args...)
-decompose!(ws::HermitianEigenWs, args...) = LAPACK.syevr!(ws, args...)
-decompose!(ws::GeneralizedEigenWs, args...) = LAPACK.ggev!(ws, args...)
+decompose!(ws::EigenWs, args...; kwargs...) = LAPACK.geevx!(ws, args...; kwargs...)
+decompose!(ws::HermitianEigenWs, args...; kwargs...) = LAPACK.syevr!(ws, args...; kwargs...)
+decompose!(ws::GeneralizedEigenWs, args...; kwargs...) = LAPACK.ggev!(ws, args...; kwargs...)
 
-function decompose!(ws::BunchKaufmanWs, uplo::AbstractChar, A::AbstractMatrix; rook=false)
+function decompose!(ws::BunchKaufmanWs, uplo::AbstractChar, A::AbstractMatrix; rook=false, kwargs...)
     if issymmetric(A)
-        return rook ? LAPACK.sytrf_rook!(ws, uplo, A) : LAPACK.sytrf!(ws, uplo, A)
+        return rook ? LAPACK.sytrf_rook!(ws, uplo, A; kwargs...) : LAPACK.sytrf!(ws, uplo, A; kwargs...)
     else
-        return rook ? LAPACK.hetrf_rook!(ws, uplo, A) : LAPACK.hetrf!(ws, uplo, A)
+        return rook ? LAPACK.hetrf_rook!(ws, uplo, A; kwargs...) : LAPACK.hetrf!(ws, uplo, A; kwargs...)
     end
 end
 
-function decompose!(ws::BunchKaufmanWs, A::Hermitian; rook=false)
-    return rook ? LAPACK.hetrf_rook!(ws, A.uplo, A.data) : LAPACK.hetrf!(ws, A.uplo, A.data)
+function decompose!(ws::BunchKaufmanWs, A::Hermitian; rook=false, kwargs...)
+    return rook ? LAPACK.hetrf_rook!(ws, A.uplo, A.data; kwargs...) : LAPACK.hetrf!(ws, A.uplo, A.data; kwargs...)
 end
-function decompose!(ws::BunchKaufmanWs, A::Symmetric; rook=false)
-    return rook ? LAPACK.sytrf_rook!(ws, A.uplo, A.data) : LAPACK.sytrf!(ws, A.uplo, A.data)
-end
-
-function decompose!(ws::CholeskyPivotedWs, uplo::AbstractChar, A::AbstractMatrix, tol=1e-16)
-    return LAPACK.pstrf!(ws, uplo, A, tol)
+function decompose!(ws::BunchKaufmanWs, A::Symmetric; rook=false, kwargs...)
+    return rook ? LAPACK.sytrf_rook!(ws, A.uplo, A.data; kwargs...) : LAPACK.sytrf!(ws, A.uplo, A.data; kwargs...)
 end
 
-function decompose!(ws::CholeskyPivotedWs, A::Union{Hermitian, Symmetric}, tol=1e-16)
-    return LAPACK.pstrf!(ws, A.uplo, A.data, tol)
+function decompose!(ws::CholeskyPivotedWs, uplo::AbstractChar, A::AbstractMatrix, tol=1e-16; kwargs...)
+    return LAPACK.pstrf!(ws, uplo, A, tol; kwargs...)
+end
+
+function decompose!(ws::CholeskyPivotedWs, A::Union{Hermitian, Symmetric}, tol=1e-16; kwargs...)
+    return LAPACK.pstrf!(ws, A.uplo, A.data, tol; kwargs...)
 end
 
 """

--- a/src/workspace.jl
+++ b/src/workspace.jl
@@ -44,7 +44,7 @@ Workspace(::typeof(LAPACK.getrf!), A::AbstractMatrix) = LUWs(A)
 Workspace(::typeof(LAPACK.geqrf!), A::AbstractMatrix) = QRWs(A)
 Workspace(::typeof(LAPACK.ormqr!), A::AbstractMatrix) = QRWs(A)
 Workspace(::typeof(LAPACK.geqrt!), A::AbstractMatrix) = QRWYWs(A)
-Workspace(::typeof(LAPACK.geqp3!), A::AbstractMatrix) = QRpWs(A)
+Workspace(::typeof(LAPACK.geqp3!), A::AbstractMatrix) = QRPivotedWs(A)
 
 Workspace(::typeof(LAPACK.gees!), A::AbstractMatrix) = SchurWs(A)
 Workspace(::typeof(LAPACK.gges!), A::AbstractMatrix) = GeneralizedSchurWs(A)
@@ -69,7 +69,7 @@ decompose!(ws::LUWs, args...) = LAPACK.getrf!(ws, args...)
 
 decompose!(ws::QRWs, args...)   = LAPACK.geqrf!(ws, args...)
 decompose!(ws::QRWYWs, args...) = LAPACK.geqrt!(ws, args...)
-decompose!(ws::QRpWs, args...)  = LAPACK.geqp3!(ws, args...)
+decompose!(ws::QRPivotedWs, args...)  = LAPACK.geqp3!(ws, args...)
 
 decompose!(ws::SchurWs, args...)            = LAPACK.gees!(ws, args...)
 decompose!(ws::GeneralizedSchurWs, args...) = LAPACK.gges!(ws, args...)

--- a/src/workspace.jl
+++ b/src/workspace.jl
@@ -107,3 +107,13 @@ end
 Alias for [`decompose!`](@ref).
 """
 const factorize! = decompose!
+
+"""
+    resize!(ws, A; kwargs...)
+
+Resizes the `ws` to be appropriate for use with matrix `A`. The `kwargs` can be used to
+communicate which features should be supported by the [`Workspace`](@ref), such as
+left and right eigenvectors while using [`EigenWs`](@ref).
+This function is mainly used for automatic resizing inside [`LAPACK functions`](@ref LAPACK).
+"""
+Base.resize!(ws::Workspace, A::AbstractMatrix; kwargs...)

--- a/test/bunch_kaufman_test.jl
+++ b/test/bunch_kaufman_test.jl
@@ -23,6 +23,8 @@ using LinearAlgebra.LAPACK
             A1, ipiv1, inf1 = decompose!(ws, 'U', copy(A))
             @test A1 == A2
             @test ipiv1 == ipiv2
+            decompose!(ws, Symmetric(rand(T, n+1, n+1)))
+            @test length(ws.ipiv) == n+1
         end
         @testset "$(T) sytrf_rook!" begin
             A = rand(T, n, n)

--- a/test/cholesky_test.jl
+++ b/test/cholesky_test.jl
@@ -10,24 +10,24 @@ using LinearAlgebra.LAPACK
             A = (A .+ A') ./ 2
             ws = CholeskyPivotedWs(copy(A))
             
-            A1, ipiv1, rank1, inf1 = LAPACK.pstrf!('U', copy(A), 1e-16) 
-            A2, ipiv2, rank2, inf2 = LAPACK.pstrf!(ws, 'U', copy(A), 1e-16)
+            A1, ipiv1, rank1, inf1 = LAPACK.pstrf!('U', copy(A), 1e-6) 
+            A2, ipiv2, rank2, inf2 = LAPACK.pstrf!(ws, 'U', copy(A), 1e-6)
             @test A1 == A2
             @test ipiv1 == ipiv2
             @test rank1 == rank2
 
             ws = Workspace(LAPACK.pstrf!, copy(A))
-            A1, ipiv1, rank1, inf1 = decompose!(ws, Hermitian(copy(A)), 1e-16)
+            A1, ipiv1, rank1, inf1 = decompose!(ws, Hermitian(copy(A)), 1e-6)
             @test A1 == A2
             @test ipiv1 == ipiv2
             @test rank1 == rank2
             
-            A1, ipiv1, rank1, inf1 = decompose!(ws, 'U', copy(A), 1e-16)
+            A1, ipiv1, rank1, inf1 = decompose!(ws, 'U', copy(A), 1e-6)
             @test A1 == A2
             @test ipiv1 == ipiv2
             @test rank1 == rank2
 
-            decompose!(ws,'U', rand(n+1, n+1), 1e-16)
+            decompose!(ws,'U', rand(n+1, n+1), 1e-6)
             @test length(ws.piv) == n+1
         end
     end

--- a/test/cholesky_test.jl
+++ b/test/cholesky_test.jl
@@ -10,24 +10,26 @@ using LinearAlgebra.LAPACK
             A = (A .+ A') ./ 2
             ws = CholeskyPivotedWs(copy(A))
             
-            A1, ipiv1, rank1, inf1 = LAPACK.pstrf!('U', copy(A), 1e-6) 
-            A2, ipiv2, rank2, inf2 = LAPACK.pstrf!(ws, 'U', copy(A), 1e-6)
+            A1, ipiv1, rank1, inf1 = LAPACK.pstrf!('U', copy(A), 1e-16) 
+            A2, ipiv2, rank2, inf2 = LAPACK.pstrf!(ws, 'U', copy(A), 1e-16)
             @test A1 == A2
             @test ipiv1 == ipiv2
             @test rank1 == rank2
 
             ws = Workspace(LAPACK.pstrf!, copy(A))
-            A1, ipiv1, rank1, inf1 = decompose!(ws, Hermitian(copy(A)), 1e-6)
+            A1, ipiv1, rank1, inf1 = decompose!(ws, Hermitian(copy(A)), 1e-16)
             @test A1 == A2
             @test ipiv1 == ipiv2
             @test rank1 == rank2
             
-            A1, ipiv1, rank1, inf1 = decompose!(ws, 'U', copy(A), 1e-6)
+            A1, ipiv1, rank1, inf1 = decompose!(ws, 'U', copy(A), 1e-16)
             @test A1 == A2
             @test ipiv1 == ipiv2
             @test rank1 == rank2
 
-            decompose!(ws,'U', rand(n+1, n+1), 1e-6)
+            A = T[1 0 0 0;0 3.1 0.1 0; 0.0 0.0 5.0 0.0; 0.1 0.0 0.3 1.0]
+            A = (A .+ A') ./ 2
+            decompose!(ws,'U', A, 1e-16)
             @test length(ws.piv) == n+1
         end
     end

--- a/test/cholesky_test.jl
+++ b/test/cholesky_test.jl
@@ -33,4 +33,5 @@ using LinearAlgebra.LAPACK
             @test length(ws.piv) == n+1
         end
     end
+    @show "ping"
 end

--- a/test/cholesky_test.jl
+++ b/test/cholesky_test.jl
@@ -26,6 +26,9 @@ using LinearAlgebra.LAPACK
             @test A1 == A2
             @test ipiv1 == ipiv2
             @test rank1 == rank2
+
+            decompose!(ws,'U', rand(n+1, n+1), 1e-16)
+            @test length(ws.piv) == n+1
         end
     end
 end

--- a/test/cholesky_test.jl
+++ b/test/cholesky_test.jl
@@ -33,5 +33,4 @@ using LinearAlgebra.LAPACK
             @test length(ws.piv) == n+1
         end
     end
-    @show "ping"
 end

--- a/test/eigen_test.jl
+++ b/test/eigen_test.jl
@@ -8,17 +8,10 @@ using LinearAlgebra.LAPACK
         A0 = randn(n, n)
         ws = EigenWs(copy(A0); lvecs = true, sense = true)
 
-        A1, WR1, WI1, VL1, VR1, ilo1, ihi1, scale1, abnrm1, rconde1, rcondv1 = LAPACK.geevx!('P',
-                                                                                             'V',
-                                                                                             'V',
-                                                                                             'V',
-                                                                                             copy(A0))
-        A2, WR2, WI2, VL2, VR2, ilo2, ihi2, scale2, abnrm2, rconde2, rcondv2 = LAPACK.geevx!(ws,
-                                                                                             'P',
-                                                                                             'V',
-                                                                                             'V',
-                                                                                             'V',
-                                                                                             copy(A0))
+        A1, WR1, WI1, VL1, VR1, ilo1, ihi1, scale1, abnrm1, rconde1, rcondv1 =
+            LAPACK.geevx!('P', 'V', 'V', 'V', copy(A0))
+        A2, WR2, WI2, VL2, VR2, ilo2, ihi2, scale2, abnrm2, rconde2, rcondv2 =
+            LAPACK.geevx!(ws, 'P', 'V', 'V', 'V', copy(A0))
 
         @test isapprox(A1, A2)
         @test isapprox(WR1, WR2)
@@ -33,12 +26,8 @@ using LinearAlgebra.LAPACK
 
         # using Workspace, factorize!
         ws = Workspace(LAPACK.geevx!, copy(A0); lvecs = true, sense = true)
-        A2, WR2, WI2, VL2, VR2, ilo2, ihi2, scale2, abnrm2, rconde2, rcondv2 = factorize!(ws,
-                                                                                          'P',
-                                                                                          'V',
-                                                                                          'V',
-                                                                                          'V',
-                                                                                          copy(A0))
+        A2, WR2, WI2, VL2, VR2, ilo2, ihi2, scale2, abnrm2, rconde2, rcondv2 =
+            factorize!(ws, 'P', 'V', 'V', 'V', copy(A0))
         @test isapprox(A1, A2)
         @test isapprox(WR1, WR2)
         @test isapprox(WI1, WI2)
@@ -49,7 +38,16 @@ using LinearAlgebra.LAPACK
         @test isapprox(scale1, scale2)
         @test isapprox(abnrm1, abnrm2)
         @test isapprox(rcondv1, rcondv2; atol = 1e-16)
-
+        
+        ws = Workspace(LAPACK.geevx!, copy(A0))
+        @test size(ws.VL, 1) == 0
+        factorize!(ws, 'P', 'V', 'N', 'N', copy(A0))
+        @test size(ws.VL, 1) != 0
+        factorize!(ws, 'P', 'V', 'V', 'N', copy(A0))
+        @test size(ws.VR, 1) != 0
+        factorize!(ws, 'P', 'V', 'V', 'E', copy(A0))
+        @test size(ws.iwork, 1) != 0
+       
         show(devnull, "text/plain", ws)
     end
 

--- a/test/eigen_test.jl
+++ b/test/eigen_test.jl
@@ -75,8 +75,6 @@ using LinearAlgebra.LAPACK
         @test isapprox(ihi1, ihi2)
         @test isapprox(scale1, scale2)
         @test isapprox(abnrm1, abnrm2)
-        @test isapprox(rconde1, rconde2; atol = 1e-16)
-        @test isapprox(rcondv1, rcondv2; atol = 1e-16)
         # using Workspace, factorize!
         ws = Workspace(LAPACK.geevx!, copy(A0); lvecs = true, sense = true)
         A2, W2, VL2, VR2, ilo2, ihi2, scale2, abnrm2, rconde2, rcondv2 = factorize!(ws, 'N',
@@ -92,8 +90,6 @@ using LinearAlgebra.LAPACK
         @test isapprox(ihi1, ihi2)
         @test isapprox(scale1, scale2)
         @test isapprox(abnrm1, abnrm2)
-        @test isapprox(rconde1, rconde2; atol = 1e-16)
-        @test isapprox(rcondv1, rcondv2; atol = 1e-16)
         show(devnull, "text/plain", ws)
     end
 end
@@ -114,6 +110,11 @@ end
         @test isapprox(w1, w2)
         @test isapprox(Z2, Z2)
         show(devnull, "text/plain", ws)
+        
+        ws = Workspace(LAPACK.syevr!, copy(A0); vecs = false)
+        w2, Z2 = factorize!(ws, 'V', 'A', 'U', randn(n+1, n+1), 0.0, 0.0, 0, 0, 1e-6)
+        @test length(ws.w) == n+1
+        @test size(ws.Z, 1) == n+1
     end
 
     @testset "Complex, square" begin
@@ -155,6 +156,17 @@ end
         @test isapprox(vl1, vl2)
         @test isapprox(vr1, vr2)
         show(devnull, "text/plain", ws)
+        
+        ws = Workspace(LAPACK.ggev!, copy(A0))
+        @test size(ws.vl, 1) == 0
+        @test size(ws.vr, 1) == 0
+        LAPACK.ggev!(ws, 'N', 'V', copy(A0), copy(B0))
+        @test size(ws.vr, 1) == n
+        LAPACK.ggev!(ws, 'V', 'V', copy(A0), copy(B0))
+        @test size(ws.vl, 1) == n
+        LAPACK.ggev!(ws, 'V', 'V', randn(n+1,n+1), randn(n+1, n+1))
+        @test size(ws.vl, 1) == n+1
+        @test size(ws.vr, 1) == n+1
     end
 
     @testset "Complex, square" begin

--- a/test/eigen_test.jl
+++ b/test/eigen_test.jl
@@ -39,14 +39,18 @@ using LinearAlgebra.LAPACK
         @test isapprox(abnrm1, abnrm2)
         @test isapprox(rcondv1, rcondv2; atol = 1e-16)
         
-        ws = Workspace(LAPACK.geevx!, copy(A0))
+        ws = Workspace(LAPACK.geevx!, copy(A0); lvecs=false, rvecs=false, sense=false)
         @test size(ws.VL, 1) == 0
+        @test_throws ArgumentError factorize!(ws, 'P', 'V', 'N', 'N', copy(A0); resize=false)
         factorize!(ws, 'P', 'V', 'N', 'N', copy(A0))
         @test size(ws.VL, 1) != 0
+        @test_throws ArgumentError factorize!(ws, 'P', 'V', 'V', 'N', copy(A0); resize=false)
         factorize!(ws, 'P', 'V', 'V', 'N', copy(A0))
         @test size(ws.VR, 1) != 0
+        @test_throws ArgumentError factorize!(ws, 'P', 'V', 'V', 'E', copy(A0); resize=false)
         factorize!(ws, 'P', 'V', 'V', 'E', copy(A0))
         @test size(ws.iwork, 1) != 0
+        @test_throws ArgumentError factorize!(ws, 'P', 'N', 'N', 'N', rand(n+1, n+1); resize=false)
        
         show(devnull, "text/plain", ws)
     end
@@ -112,9 +116,14 @@ end
         show(devnull, "text/plain", ws)
         
         ws = Workspace(LAPACK.syevr!, copy(A0); vecs = false)
+        @test_throws ArgumentError factorize!(ws, 'N', 'A', 'U', randn(n+1, n+1), 0.0, 0.0, 0, 0, 1e-6; resize=false)
+        @test_throws ArgumentError factorize!(ws, 'V', 'A', 'U', copy(A0), 0.0, 0.0, 0, 0, 1e-6; resize=false)
         w2, Z2 = factorize!(ws, 'V', 'A', 'U', randn(n+1, n+1), 0.0, 0.0, 0, 0, 1e-6)
         @test length(ws.w) == n+1
         @test size(ws.Z, 1) == n+1
+        
+        @test_throws ArgumentError factorize!(ws, 'V', 'I', 'U', randn(n+1, n+1), 0.0, 0.0, 10, 5, 1e-6)
+        @test_throws ArgumentError factorize!(ws, 'V', 'V', 'U', randn(n+1, n+1), 2.0, 1.0, 0, 0, 1e-6)
     end
 
     @testset "Complex, square" begin
@@ -160,10 +169,13 @@ end
         ws = Workspace(LAPACK.ggev!, copy(A0))
         @test size(ws.vl, 1) == 0
         @test size(ws.vr, 1) == 0
+        @test_throws ArgumentError LAPACK.ggev!(ws, 'N', 'V', copy(A0), copy(B0); resize=false)
         LAPACK.ggev!(ws, 'N', 'V', copy(A0), copy(B0))
         @test size(ws.vr, 1) == n
+        @test_throws ArgumentError LAPACK.ggev!(ws, 'V', 'V', copy(A0), copy(B0); resize=false)
         LAPACK.ggev!(ws, 'V', 'V', copy(A0), copy(B0))
         @test size(ws.vl, 1) == n
+        @test_throws ArgumentError LAPACK.ggev!(ws, 'V', 'V', randn(n+1,n+1), randn(n+1, n+1), resize=false)
         LAPACK.ggev!(ws, 'V', 'V', randn(n+1,n+1), randn(n+1, n+1))
         @test size(ws.vl, 1) == n+1
         @test size(ws.vr, 1) == n+1

--- a/test/lu_test.jl
+++ b/test/lu_test.jl
@@ -28,6 +28,8 @@ m = 2
             @test UpperTriangular(reshape(res.U, n, n)) ≈ F.U
 
             show(devnull, "text/plain", linws)
+            resize!(linws, rand(elty, 5,5))
+            @test length(linws.ipiv) == 5
             # res = LU(LAPACK.getrf!(collect(copy(A)'), linws)...)
             # @test UpperTriangular(reshape(res.U, n, n)) ≈ F.U
 

--- a/test/qr_test.jl
+++ b/test/qr_test.jl
@@ -19,9 +19,14 @@ using LinearAlgebra.LAPACK
             AT1, tau1 = factorize!(ws, copy(A0))
             @test AT1 == AT
             @test tau1 == tau
+            
+            @test_throws ArgumentError factorize!(ws, rand(n+1, n+1); resize=false)
+            factorize!(ws, rand(n+1, n+1))
+            @test size(ws.τ , 1) == n+1
         end
 
         @testset "ormqr!" begin
+            ws = Workspace(LAPACK.geqrf!, copy(A0))
             C = randn(n, n)
             tau = randn(n)
             ws.τ .= tau
@@ -56,6 +61,9 @@ end
             @test AT1 == AT
             @test isapprox(taut1, taut)
             show(devnull, "text/plain", ws)
+            @test_throws ArgumentError factorize!(ws, rand(n-1, n-1); resize=false)
+            factorize!(ws, rand(n-1, n-1))
+            @test size(ws.T, 1) == n-1
         end
     end
 end
@@ -79,6 +87,9 @@ end
             q1 = QRPivoted(factorize!(ws, copy(A))...)
             @test isapprox(Matrix(q1), Matrix(q2))
 
+            @test_throws ArgumentError factorize!(ws, rand(n+1, n+1); resize=false)
+            factorize!(ws, rand(n+1, n+1))
+            @test size(ws.τ , 1) == n+1
             show(devnull, "text/plain", ws)
         end
     end

--- a/test/qr_test.jl
+++ b/test/qr_test.jl
@@ -9,16 +9,15 @@ using LinearAlgebra.LAPACK
         ws = QRWs(A0)
         @testset "geqrf!" begin
             A = copy(A0)
-            AT, tau = LAPACK.geqrf!(ws, A)
+            qr1 = QR(LAPACK.geqrf!(ws, A)...)
 
-            AT1, tau1 = LAPACK.geqrf!(copy(A0), randn(n))
-            @test AT1 == AT
-            @test tau1 == tau
+            qr2 = QR(LAPACK.geqrf!(copy(A0), randn(n))...)
+            @test isapprox(Matrix(qr1), Matrix(qr2))
             # using Workspace, factorize!
             ws = Workspace(LAPACK.geqrf!, copy(A0))
-            AT1, tau1 = factorize!(ws, copy(A0))
-            @test AT1 == AT
-            @test tau1 == tau
+            qr2 = QR(factorize!(ws, copy(A0))...)
+            
+            @test isapprox(Matrix(qr1), Matrix(qr2))
             
             @test_throws ArgumentError factorize!(ws, rand(n+1, n+1); resize=false)
             factorize!(ws, rand(n+1, n+1))
@@ -51,15 +50,13 @@ end
             A = copy(A0)
             ws = QRWYWs(A)
 
-            AT, taut = LAPACK.geqrt!(ws, copy(A))
-            AT1, taut1 = LAPACK.geqrt!(copy(A0), zeros(size(ws.T)))
-            @test AT1 == AT
-            @test isapprox(taut1, taut)
+            qr1 = LinearAlgebra.QRCompactWY(LAPACK.geqrt!(ws, copy(A))...)
+            qr2 = LinearAlgebra.QRCompactWY(LAPACK.geqrt!(copy(A0), zeros(size(ws.T)))...)
+            @test isapprox(Matrix(qr1), Matrix(qr2))
             # using Workspace, factorize!
             ws = Workspace(LAPACK.geqrt!, copy(A))
-            AT, taut = factorize!(ws, A)
-            @test AT1 == AT
-            @test isapprox(taut1, taut)
+            qr1 = LinearAlgebra.QRCompactWY(factorize!(ws, A)...)
+            @test isapprox(Matrix(qr1), Matrix(qr2))
             show(devnull, "text/plain", ws)
             @test_throws ArgumentError factorize!(ws, rand(n-1, n-1); resize=false)
             factorize!(ws, rand(n-1, n-1))

--- a/test/qr_test.jl
+++ b/test/qr_test.jl
@@ -60,28 +60,24 @@ end
     end
 end
 
-@testset "QRpWs" begin
+@testset "QRPivotedWs" begin
     n = 3
     @testset "Real, square" begin
         A0 = randn(n, n)
 
         @testset "geqp3!" begin
             A = copy(A0)
-            ws = QRpWs(A)
-            AT, taut, jpvt = LAPACK.geqp3!(ws, copy(A))
+            ws = QRPivotedWs(A)
+            q1 = QRPivoted(LAPACK.geqp3!(ws, copy(A))...)
 
-            AT1, taut1, jpvt1 = LAPACK.geqp3!(copy(A0), zeros(Int, length(ws.jpvt)),
-                                              zeros(size(ws.τ)))
-            @test isapprox(AT1, AT)
-            @test isapprox(jpvt1, jpvt)
-            @test isapprox(taut1, taut)
+            q2 = QRPivoted(LAPACK.geqp3!(copy(A0), zeros(Int, length(ws.jpvt)),
+                                              zeros(size(ws.τ)))...)
+            @test isapprox(Matrix(q1), Matrix(q2))
 
             # using Workspace, factorize!
             ws = Workspace(LAPACK.geqp3!, copy(A))
-            AT, taut, jpvt = factorize!(ws, copy(A))
-            @test isapprox(AT1, AT)
-            @test isapprox(jpvt1, jpvt)
-            @test isapprox(taut1, taut)
+            q1 = QRPivoted(factorize!(ws, copy(A))...)
+            @test isapprox(Matrix(q1), Matrix(q2))
 
             show(devnull, "text/plain", ws)
         end


### PR DESCRIPTION
Hi,

This PR implements `Base.resize!` for all `Workspaces` and also a `resize=true` keyword argument for all the LAPACK functions so that workspaces are automatically resized in case it is needed. This includes cases where certain workbuffers weren’t allocated yet because functionality was not required at creation, one example is left and right eigenvectors for the EigenWs. 

Cheers,
Louis