### PR TITLE
fix method definition overwritten on the same line

### DIFF
--- a/src/qr.jl
+++ b/src/qr.jl
@@ -218,7 +218,7 @@ for (geqrt, elty) in ((:dgeqrt_, :Float64),
                       (:zgeqrt_, :ComplexF64),
                       (:cgeqrt_, :ComplexF32))
     @eval begin
-        function Base.resize!(ws::QRWYWs, A::StridedMatrix; blocksize=36)
+        function Base.resize!(ws::QRWYWs, A::StridedMatrix{$elty}; blocksize=36)
             require_one_based_indexing(A)
             chkstride1(A)
             m, n = BlasInt.(size(A))


### PR DESCRIPTION
It looks like #17 included changes that broke precompilation for this module. I get several long warnings like this:

```
WARNING: Method definition resize!##kw(Any, typeof(Base.resize!), FastLapackInterface.QRWYWs{R, MT} where MT<:Union{DenseArray{R, 2}, Base.ReinterpretArray{R, 2, S, A, IsReshaped} where S where IsReshaped where A<:Union{Base.SubArray{T, N, A, I, tr
...
} where T) in module FastLapackInterface at d:\visser_mn\.julia\packages\FastLapackInterface\ShGQa\src\qr.jl:221 overwritten on the same line (check for duplicate calls to `include`).
  ** incremental compilation may be fatally broken for this module **
```

Based on the surrounding code it looks like this might be what was intended, but please check since I am not familiar with the code.
