### PR TITLE
Resize fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         version:
           - '1.6'
-          - '1.8.0-rc1'
+          - '1.8.0'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FastLapackInterface"
 uuid = "29a986be-02c6-4525-aec4-84b980013641"
 authors = ["Louis Ponet, Michel Juillard"]
-version = "1.2.4"
+version = "1.2.5"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/FastLapackInterface.jl
+++ b/src/FastLapackInterface.jl
@@ -16,7 +16,7 @@ else
 end
 
 abstract type Workspace end
-
+include("exceptions.jl")
 include("lu.jl")
 export LUWs
 include("qr.jl")

--- a/src/cholesky.jl
+++ b/src/cholesky.jl
@@ -45,10 +45,12 @@ for (pstrf, elty, rtyp) in
      (:zpstrf_,:ComplexF64,:Float64),
      (:cpstrf_,:ComplexF32,:Float32))
     @eval begin
-        function Base.resize!(ws::CholeskyPivotedWs, A::AbstractMatrix{$elty})
+        function Base.resize!(ws::CholeskyPivotedWs, A::AbstractMatrix{$elty}; work = true)
             n = checksquare(A)
-            resize!(ws.work, 2n)
             resize!(ws.piv, n)
+            if work
+                resize!(ws.work, 2n)
+            end
             return ws
         end
         function CholeskyPivotedWs(A::AbstractMatrix{$elty})
@@ -61,11 +63,12 @@ for (pstrf, elty, rtyp) in
             chkuplo(uplo)
             rank = Ref{BlasInt}()
             info = Ref{BlasInt}()
-            if length(ws.piv) < n
+            nws = length(ws.piv)
+            if nws != n
                 if resize
-                    resize!(ws, A)
+                    resize!(ws, A; work = nws < n)
                 else
-                    throw(ArgumentError("Workspace is too small, use resize!(ws, A)."))
+                    throw(WorkspaceSizeError(nws, n))
                 end
             end
                 

--- a/src/exceptions.jl
+++ b/src/exceptions.jl
@@ -1,7 +1,13 @@
 struct SingularException <: Exception end
 
 struct DggesException <: Exception
-    error_nbr::Int64
+    error_nbr::Int
 end
 
 Base.showerror(io::IO, e::DggesException) = print(io, "dgges error ", e.error_nbr)
+
+struct WorkspaceSizeError <: Exception
+    nws::Int
+    n::Int
+end
+Base.showerror(io::IO, e::WorkspaceSizeError) = print(io, "Workspace has the wrong size: expected $(e.n), got $(e.nws).\nUse resize!(ws, A).")

--- a/src/lu.jl
+++ b/src/lu.jl
@@ -45,11 +45,13 @@ for (getrf, elty) in ((:dgetrf_, :Float64),
                       (:cgetrf_, :ComplexF32))
     @eval begin
         function getrf!(ws::LUWs, A::AbstractMatrix{$elty}; resize=true)
-            if min(size(A)...) <= length(ws.ipiv)
+            nws = length(ws.ipiv)
+            n = min(size(A)...)
+            if n != nws 
                 if resize
                     resize!(ws, A)
                 else
-                    throw(ArgumentError("Allocated Workspace is too small."))
+                    throw(WorkspaceSizeError(nws, n))
                 end
             end
             require_one_based_indexing(A)

--- a/src/qr.jl
+++ b/src/qr.jl
@@ -49,17 +49,19 @@ for (geqrf, elty) in ((:dgeqrf_, :Float64),
                       (:zgeqrf_, :ComplexF64),
                       (:cgeqrf_, :ComplexF32))
     @eval begin
-        function Base.resize!(ws::QRWs, A::StridedMatrix{$elty})
+        function Base.resize!(ws::QRWs, A::StridedMatrix{$elty}; work=true)
             m, n = size(A)
             lda = max(1, stride(A, 2))
             resize!(ws.τ, min(m, n))
-            info = Ref{BlasInt}()
-            ccall((@blasfunc($geqrf), liblapack), Cvoid,
-                  (Ref{BlasInt}, Ref{BlasInt}, Ptr{$elty}, Ref{BlasInt}, Ptr{$elty},
-                   Ptr{$elty}, Ref{BlasInt}, Ptr{BlasInt}),
-                  m, n, A, lda, ws.τ, ws.work, -1, info)
-            chklapackerror(info[])
-            resize!(ws.work, BlasInt(real(ws.work[1])))
+            if work
+                info = Ref{BlasInt}()
+                ccall((@blasfunc($geqrf), liblapack), Cvoid,
+                      (Ref{BlasInt}, Ref{BlasInt}, Ptr{$elty}, Ref{BlasInt}, Ptr{$elty},
+                       Ptr{$elty}, Ref{BlasInt}, Ptr{BlasInt}),
+                      m, n, A, lda, ws.τ, ws.work, -1, info)
+                chklapackerror(info[])
+                resize!(ws.work, BlasInt(real(ws.work[1])))
+            end
             return ws
         end
         QRWs(A::StridedMatrix{$elty}) =
@@ -69,11 +71,13 @@ for (geqrf, elty) in ((:dgeqrf_, :Float64),
             require_one_based_indexing(A)
             chkstride1(A)
             m, n = size(A)
-            if length(ws) < min(m, n)
+            nws = length(ws)
+            minn = min(m, n)
+            if nws != minn 
                 if resize
-                    resize!(ws, A)
+                    resize!(ws, A; work = minn > nws)
                 else
-                    throw(ArgumentError("Workspace is too small, use resize!(ws, A)."))
+                    throw(WorkspaceSizeError(nws, minn))
                 end
             end
             lda = max(1, stride(A, 2))
@@ -145,7 +149,7 @@ mutable struct QRWYWs{R<:Number,MT<:StridedMatrix{R}} <: Workspace
     T::MT
 end
 
-function Base.resize!(ws::QRWYWs, A::StridedMatrix; blocksize=36)
+function Base.resize!(ws::QRWYWs, A::StridedMatrix; blocksize=36, work=true)
     require_one_based_indexing(A)
     chkstride1(A)
     m, n = BlasInt.(size(A))
@@ -153,7 +157,9 @@ function Base.resize!(ws::QRWYWs, A::StridedMatrix; blocksize=36)
     m1 = min(m, n)
     nb = min(m1, blocksize)
     ws.T = similar(ws.T,  nb, m1)
-    resize!(ws.work, nb*n)
+    if work
+        resize!(ws.work, nb*n)
+    end
     return ws
 end
 
@@ -170,14 +176,14 @@ for (geqrt, elty) in ((:dgeqrt_, :Float64),
         m, n = size(A)
         minmn = min(m, n)
         nb = size(ws.T, 1)
-        if nb > minmn
+        if nb != minmn
             if resize
-                resize!(ws, A)
-                nb = size(ws.T, 1)
+                resize!(ws, A, work = nb < minmn)
             else
-                throw(ArgumentError("Allocated workspace block size $nb > $minmn too large.\nUse resize!(ws, A)."))
+                throw(WorkspaceSizeError(nb, minmn))
             end
         end
+        nb = size(ws.T, 1)
 
         lda = max(1, stride(A, 2))
         work = ws.work
@@ -260,20 +266,22 @@ for (geqp3, elty) in ((:dgeqp3_, :Float64),
                       (:zgeqp3_, :ComplexF64),
                       (:cgeqp3_, :ComplexF32))
     @eval begin
-        function Base.resize!(ws::QRPivotedWs, A::StridedMatrix{$elty})
+        function Base.resize!(ws::QRPivotedWs, A::StridedMatrix{$elty}; work=true)
             require_one_based_indexing(A)
             chkstride1(A)
             m, n = size(A)
             RldA = max(1, stride(A, 2))
             resize!(ws.jpvt, n)
             resize!(ws.τ, min(m, n))
-            info = Ref{BlasInt}()
-            ccall((@blasfunc($geqp3), liblapack), Cvoid,
-                  (Ref{BlasInt}, Ref{BlasInt}, Ptr{$elty}, Ref{BlasInt}, Ptr{BlasInt},
-                   Ptr{$elty}, Ptr{$elty}, Ref{BlasInt}, Ref{BlasInt}),
-                  m, n, A, RldA, ws.jpvt, ws.τ, ws.work, -1, info)
-            chklapackerror(info[])
-            resize!(ws.work, BlasInt(real(ws.work[1])))
+            if work
+                info = Ref{BlasInt}()
+                ccall((@blasfunc($geqp3), liblapack), Cvoid,
+                      (Ref{BlasInt}, Ref{BlasInt}, Ptr{$elty}, Ref{BlasInt}, Ptr{BlasInt},
+                       Ptr{$elty}, Ptr{$elty}, Ref{BlasInt}, Ref{BlasInt}),
+                      m, n, A, RldA, ws.jpvt, ws.τ, ws.work, -1, info)
+                chklapackerror(info[])
+                resize!(ws.work, BlasInt(real(ws.work[1])))
+            end
             return ws
         end
         QRPivotedWs(A::StridedMatrix{$elty}) =
@@ -281,18 +289,13 @@ for (geqp3, elty) in ((:dgeqp3_, :Float64),
 
         function geqp3!(ws::QRPivotedWs{$elty}, A::AbstractMatrix{$elty}; resize=true)
             m, n = size(A)
-            if length(ws.τ) != min(m, n)
+            nws = length(ws.jpvt)
+            minn =  min(m, n)
+            if nws != n || minn != length(ws.τ)
                 if resize
-                    resize!(ws, A)
+                    resize!(ws, A; work = n > nws)
                 else
-                    throw(ArgumentError("Workspace is too small, use resize!(ws, A)."))
-                end
-            end
-            if length(ws.jpvt) != n
-                if resize
-                    resize!(ws, A)
-                else
-                    throw(ArgumentError("Workspace is too small, use resize!(ws, A)."))
+                    throw(WorkspaceSizeError(nws, minn))
                 end
             end
             lda = stride(A, 2)
@@ -335,7 +338,7 @@ for (ormqr, orgqr, elty) in ((:dormqr_, :dorgqr_,  :Float64),
                       
     @eval function ormqr!(ws::Union{QRWs{$elty}, QRPivotedWs{$elty}}, side::AbstractChar, trans::AbstractChar,
                           A::AbstractMatrix{$elty},
-                          C::AbstractVecOrMat{$elty}; resize=true)
+                          C::AbstractVecOrMat{$elty})
         require_one_based_indexing(A, C)
         chktrans(trans)
         chkside(side)

--- a/src/qr.jl
+++ b/src/qr.jl
@@ -400,7 +400,7 @@ for (ormqr, orgqr, elty) in ((:dormqr_, :dorgqr_,  :Float64),
               info)
             chklapackerror(info[])
         if n < size(A,2)
-            return view(A, :, 1:n)
+            return A[:, 1:n]
         else
             return A
         end

--- a/test/bunch_kaufman_test.jl
+++ b/test/bunch_kaufman_test.jl
@@ -23,8 +23,11 @@ using LinearAlgebra.LAPACK
             A1, ipiv1, inf1 = decompose!(ws, 'U', copy(A))
             @test A1 == A2
             @test ipiv1 == ipiv2
-            decompose!(ws, Symmetric(rand(T, n+1, n+1)))
-            @test length(ws.ipiv) == n+1
+            for div in (-1,1)
+                @test_throws FastLapackInterface.WorkspaceSizeError decompose!(ws, Symmetric(rand(T, n+div, n+div)); resize=false)
+                decompose!(ws, Symmetric(rand(T, n+div, n+div)))
+                @test length(ws.ipiv) == n+div
+            end
         end
         @testset "$(T) sytrf_rook!" begin
             A = rand(T, n, n)

--- a/test/eigen_test.jl
+++ b/test/eigen_test.jl
@@ -50,12 +50,11 @@ using LinearAlgebra.LAPACK
         @test_throws ArgumentError factorize!(ws, 'P', 'V', 'V', 'E', copy(A0); resize=false)
         factorize!(ws, 'P', 'V', 'V', 'E', copy(A0))
         @test size(ws.iwork, 1) != 0
-        @test_throws ArgumentError factorize!(ws, 'P', 'N', 'N', 'N', rand(n+1, n+1); resize=false)
-        A2, WR2, WI2, VL2, VR2, ilo2, ihi2, scale2, abnrm2, rconde2, rcondv2 =
-            factorize!(ws, 'P', 'N', 'N', 'N', rand(n+1, n+1))
-
-        @test length(WR2) == n+1
-       
+        for div in (-1, 1)            
+            @test_throws FastLapackInterface.WorkspaceSizeError factorize!(ws, 'P', 'N', 'N', 'N',rand(n+div, n+div); resize=false)
+            factorize!(ws, 'P', 'N', 'N', 'N',rand(n+div, n+div))
+            @test length(ws.W) == n+div
+        end
         show(devnull, "text/plain", ws)
     end
 
@@ -121,18 +120,17 @@ end
         show(devnull, "text/plain", ws)
         
         ws = Workspace(LAPACK.syevr!, copy(A0); vecs = false)
-        @test_throws ArgumentError factorize!(ws, 'N', 'A', 'U', randn(n+1, n+1), 0.0, 0.0, 0, 0, 1e-6; resize=false)
-        @test_throws ArgumentError factorize!(ws, 'V', 'A', 'U', copy(A0), 0.0, 0.0, 0, 0, 1e-6; resize=false)
-        w2, Z2 = factorize!(ws, 'V', 'A', 'U', randn(n+1, n+1), 0.0, 0.0, 0, 0, 1e-6)
-        @test length(ws.w) == n+1
-        @test size(ws.Z, 1) == n+1
+        for div in (-1, 1)            
+            @test_throws FastLapackInterface.WorkspaceSizeError factorize!(ws, 'N', 'A', 'U', randn(n+div, n+div), 0.0, 0.0, 0, 0, 1e-6; resize=false)
+            @test_throws FastLapackInterface.WorkspaceSizeError factorize!(ws, 'V', 'A', 'U', randn(n+div, n+div), 0.0, 0.0, 0, 0, 1e-6; resize=false)
+            w2, Z2 = factorize!(ws, 'V', 'A', 'U', randn(n+div, n+div), 0.0, 0.0, 0, 0, 1e-6)
+            @test length(ws.w) == n+div
+            @test size(ws.Z, 1) == n+div
+        end
         w2, Z2 = factorize!(ws, 'V', 'A', 'U', copy(A0), 0.0, 0.0, 0, 0, 1e-16)
         @test length(w2) == n
         @test sum(abs.(Matrix(Eigen(w2, Z2)) .- A0)) < 1e-12
         
-        
-        @test_throws ArgumentError factorize!(ws, 'V', 'I', 'U', randn(n+1, n+1), 0.0, 0.0, 10, 5, 1e-6)
-        @test_throws ArgumentError factorize!(ws, 'V', 'V', 'U', randn(n+1, n+1), 2.0, 1.0, 0, 0, 1e-6)
     end
 
     @testset "Complex, square" begin
@@ -184,12 +182,13 @@ end
         @test_throws ArgumentError LAPACK.ggev!(ws, 'V', 'V', copy(A0), copy(B0); resize=false)
         LAPACK.ggev!(ws, 'V', 'V', copy(A0), copy(B0))
         @test size(ws.vl, 1) == n
-        @test_throws ArgumentError LAPACK.ggev!(ws, 'V', 'V', randn(n+1,n+1), randn(n+1, n+1), resize=false)
-        LAPACK.ggev!(ws, 'V', 'V', randn(n+1,n+1), randn(n+1, n+1))
-        @test size(ws.vl, 1) == n+1
-        @test size(ws.vr, 1) == n+1
-        αr1, αi1, β1, vl1, vr1 = LAPACK.ggev!(ws, 'V', 'V', copy(A0), copy(B0))
-        @test length(αr1) == n
+
+        for div in (-1,1)
+            @test_throws FastLapackInterface.WorkspaceSizeError LAPACK.ggev!(ws, 'V', 'V', randn(n+div,n+div), randn(n+div, n+div), resize=false)
+            LAPACK.ggev!(ws, 'V', 'V', randn(n+div,n+div), randn(n+div, n+div))
+            @test size(ws.vl, 1) == n+div
+            @test size(ws.vr, 1) == n+div
+        end
     end
 
     @testset "Complex, square" begin

--- a/test/lu_test.jl
+++ b/test/lu_test.jl
@@ -28,8 +28,12 @@ m = 2
             @test UpperTriangular(reshape(res.U, n, n)) ≈ F.U
 
             show(devnull, "text/plain", linws)
-            resize!(linws, rand(elty, 5,5))
-            @test length(linws.ipiv) == 5
+            for div in (-1, 1)
+                @test_throws FastLapackInterface.WorkspaceSizeError factorize!(linws, rand(elty, n+div, n+div); resize=false)
+                factorize!(linws, rand(elty, n+div, n+div))
+                @test length(linws.ipiv) == n+div
+            end
+
             # res = LU(LAPACK.getrf!(collect(copy(A)'), linws)...)
             # @test UpperTriangular(reshape(res.U, n, n)) ≈ F.U
 

--- a/test/qr_test.jl
+++ b/test/qr_test.jl
@@ -18,10 +18,11 @@ using LinearAlgebra.LAPACK
             qr2 = QR(factorize!(ws, copy(A0))...)
             
             @test isapprox(Matrix(qr1), Matrix(qr2))
-            
-            @test_throws ArgumentError factorize!(ws, rand(n+1, n+1); resize=false)
-            factorize!(ws, rand(n+1, n+1))
-            @test size(ws.τ , 1) == n+1
+            for div in (-1, 1)            
+                @test_throws FastLapackInterface.WorkspaceSizeError factorize!(ws, rand(n+div, n+div); resize=false)
+                factorize!(ws, rand(n+div, n+div))
+                @test size(ws.τ , 1) == n+div
+            end
         end
 
         @testset "ormqr!" begin
@@ -67,10 +68,13 @@ end
             qr1 = LinearAlgebra.QRCompactWY(factorize!(ws, A)...)
             @test isapprox(Matrix(qr1), Matrix(qr2))
             show(devnull, "text/plain", ws)
-            @test_throws ArgumentError factorize!(ws, rand(n-1, n-1); resize=false)
-            factorize!(ws, rand(n-1, n-1))
-            @test size(ws.T, 1) == n-1
+            for div in (-1, 1)            
+                @test_throws FastLapackInterface.WorkspaceSizeError factorize!(ws, rand(n+div, n+div); resize=false)
+                factorize!(ws, rand(n+div, n+div))
+                @test size(ws.T , 1) == n+div
+            end
         end
+            
     end
 end
 
@@ -93,9 +97,11 @@ end
             q1 = QRPivoted(factorize!(ws, copy(A))...)
             @test isapprox(Matrix(q1), Matrix(q2))
 
-            @test_throws ArgumentError factorize!(ws, rand(n+1, n+1); resize=false)
-            factorize!(ws, rand(n+1, n+1))
-            @test size(ws.τ , 1) == n+1
+            for div in (-1, 1)            
+                @test_throws FastLapackInterface.WorkspaceSizeError factorize!(ws, rand(n+div, n+div); resize=false)
+                factorize!(ws, rand(n+div, n+div))
+                @test size(ws.τ, 1) == n+div
+            end
             show(devnull, "text/plain", ws)
         end
         @testset "orgqr!" begin

--- a/test/schur_test.jl
+++ b/test/schur_test.jl
@@ -20,6 +20,12 @@ using LinearAlgebra.LAPACK
         @test isapprox(vs1, vs2)
         @test isapprox(wr1, wr2)
         show(devnull, "text/plain", ws)
+        for div in (-1,1)
+            @test_throws FastLapackInterface.WorkspaceSizeError factorize!(ws, 'V', randn(n+div, n+div); resize=false)
+            factorize!(ws, 'V', randn(n+div, n+div))
+            @test length(ws.wr) == n+div
+        end
+        
     end
 
     @testset "Real, square, select" begin
@@ -66,6 +72,12 @@ end
         @test isapprox(vsl1, vsl2)
         @test isapprox(vsr1, vsr2)
         show(devnull, "text/plain", ws)
+
+        for div in (-1,1)
+            @test_throws FastLapackInterface.WorkspaceSizeError factorize!(ws, 'V', 'V', randn(n+div, n+div), randn(n+div, n+div); resize=false)
+            factorize!(ws, 'V', 'V', randn(n+div, n+div), randn(n+div, n+div))
+            @test length(ws.αr) == n+div
+        end
     end
 
     #TODO: This should be tested with something realistic


### PR DESCRIPTION
This PR holds various fixes to the resizing of workspaces, and added additional tests for that.
A new exception was added to communicate the workspace size errors.
This together with a `work=true` kwarg on the `Base.resize!` methods has cleaned up quite some code.

The version is also bumped to 1.2.5.