### PR TITLE
Add a wrapper using the default parameters

### DIFF
--- a/src/eigen.jl
+++ b/src/eigen.jl
@@ -1,6 +1,7 @@
 # Workspaces for Eigenvalue decomposition
 using LinearAlgebra.LAPACK: chkfinite
 import LinearAlgebra.LAPACK: geevx!, syevr!, ggev!
+import LinearAlgebra: Algorithm, default_eigen_alg, RobustRepresentations, sorteig!, eigen!
 
 """
     EigenWs
@@ -473,6 +474,14 @@ syevr!(ws::HermitianEigenWs, jobz::AbstractChar, range::AbstractChar,
     uplo::AbstractChar, A::AbstractMatrix,
     vl::AbstractFloat, vu::AbstractFloat, il::Integer, iu::Integer,
     abstol::AbstractFloat; resize = true)
+
+function eigen!(ws::HermitianEigenWs, A::Hermitian; alg::Algorithm=default_eigen_alg(A), sortby::Union{Function,Nothing}=nothing)
+    if alg === RobustRepresentations()
+        Eigen(sorteig!(syevr!(ws, 'V', 'A', A.uplo, A.data, 0.0, 0.0, 0, 0, -1.0)..., sortby)...)
+    else
+        throw(ArgumentError("Unsupported value for `alg` keyword."))
+    end
+end
 
 """
     GeneralizedEigenWs


### PR DESCRIPTION
This is a great package, which I'm dropping in to replace `eigen!(Hermitian(H))`, so it seems convenient to provide a wrapper that uses the same defaults provided by `LinearAlgebra`, which I did here just for `syevr!`. There are a few places the default could be implemented:
- another method for `eigen!`
- another method for `syevr!`, like LinearAlgebra does for `syevr!(jobz, A) = syevr!(jobz, 'A', 'U', A, 0.0, 0.0, 0, 0, -1.0)`
- default parameter values for your `decompose!` wrapper

I chose the first because it gives the most simple interface: now I use `eigen!(ws, Hermitian(H))`. It's nicer than `Eigen(LinearAlgebra.sorteig!(LAPACK.syevr!(ws, 'V', 'A', 'U', H, 0.0, 0.0, 0, 0, -1.0)...)...)`

What do you think? If you agree, then this can be done for some of the other algorithms and the documentation updated. 